### PR TITLE
Correção de um link para a página da política que esta na página dos termos.

### DIFF
--- a/src/main/resources/templates/termosCondicoes.html
+++ b/src/main/resources/templates/termosCondicoes.html
@@ -114,7 +114,7 @@
                 <h5>3. Privacidade</h5>
                 <p>
                     Seu uso do site também é regido pela nossa Política de Privacidade.
-                    Consulte a <a href="URL-da-sua-politica-de-privacidade">Política de Privacidade</a>
+                    Consulte a <a href="/politica-de-privacidade">Política de Privacidade</a>
                     para entender como coletamos, usamos e protegemos as informações que você nos fornece.
                 </p>
 


### PR DESCRIPTION
Existe um link na página dos termos e condições que direciona para a página da política de privacidade. Antes não havia sido configurado, agora foi.


![Captura de tela 2023-09-03 194840](https://github.com/felipe-laudano/goservice/assets/127693428/532e498f-d7ff-49e0-907e-025823198674)
