### PR TITLE
Implementando cacheamento ao buscar a lista completa de usuários com administrador.

### DIFF
--- a/src/main/java/com/soulcode/goserviceapp/domain/Usuario.java
+++ b/src/main/java/com/soulcode/goserviceapp/domain/Usuario.java
@@ -5,7 +5,6 @@ import jakarta.persistence.*;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;

--- a/src/main/java/com/soulcode/goserviceapp/service/UsuarioService.java
+++ b/src/main/java/com/soulcode/goserviceapp/service/UsuarioService.java
@@ -7,6 +7,7 @@ import com.soulcode.goserviceapp.domain.Usuario;
 import com.soulcode.goserviceapp.repository.UsuarioRepository;
 import com.soulcode.goserviceapp.service.exceptions.UsuarioNaoEncontradoException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -34,7 +35,9 @@ public class UsuarioService {
         throw new UsuarioNaoEncontradoException();
     }
 
+    @Cacheable(cacheNames = "redisCache")
     public List<Usuario> findAll(){
+        System.err.println("BUSCANDO USUARIOS NO BANCO DE DADOS...");
         return usuarioRepository.findAll();
     }
 


### PR DESCRIPTION
O primeiro passo seria colocar o "Serializable" no domínio de Usuarios, porém o próprio UserDetails ja possui essa função dentro de si.

- [x] Então implementei o cacheamento em UsuarioService:

![image](https://github.com/felipe-laudano/goservice/assets/121506621/ba9da8b0-d9f9-4680-a4b2-132bc211a19a)

- [x] Buscando Usuarios pela primeira vez o console nos mostra a mensagem de que está sendo procurado diretamente no banco de dados, porém após isso fica por um período de 3 minutos o comando cacheado pelo Redis.

![image](https://github.com/felipe-laudano/goservice/assets/121506621/858ab026-e20d-4dc7-a930-4606c6be2b94)

