### PR TITLE
Resolução de bug durante o cacheamento de usuário

### DIFF
--- a/src/main/java/com/soulcode/goserviceapp/service/UsuarioService.java
+++ b/src/main/java/com/soulcode/goserviceapp/service/UsuarioService.java
@@ -35,7 +35,7 @@ public class UsuarioService {
         throw new UsuarioNaoEncontradoException();
     }
 
-    @Cacheable(cacheNames = "redisCache")
+    @Cacheable(cacheNames = "redisCache2")
     public List<Usuario> findAll(){
         System.err.println("BUSCANDO USUARIOS NO BANCO DE DADOS...");
         return usuarioRepository.findAll();

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,7 +4,7 @@ spring.datasource.username=${mysql_username}
 spring.datasource.password=${mysql_password}
 
 # REDIS
-spring.cache.cache-names=redisCache
+spring.cache.cache-names=redisCache,redisCache2
 spring.cache.redis.time-to-live=180000
 spring.cache.type=redis
 spring.data.redis.host=localhost


### PR DESCRIPTION
Correção do seguinte bug, por algum motivo o redis estava "crachando" ao realizar o cacheamento em serviços e usuários na página administrativa, como os dois cacheamentos são de metodos findAll foi feita a seguinte mudança:

- [x] Renomeação de "cacheNames" em UsuarioService:

![image](https://github.com/felipe-laudano/goservice/assets/121506621/d7bfc635-9bc3-4109-b568-4555fb40d171)

- [x] Adição de um nome em application.properties:

![image](https://github.com/felipe-laudano/goservice/assets/121506621/9f5589a7-63ab-4ab1-bf45-43ffc067c98a)
